### PR TITLE
Fix error that would accumulate crontab entries

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,5 @@
 python -c 'from owl import *; starting_message()' # Run starting message and logo
 python main.py # Run Update once directly at the start
-echo "$CRONVARS2" "cd /app && python main.py" >> mycron
+echo "$CRONVARS2" "cd /app && python main.py" > mycron
 crontab mycron
 crond -f


### PR DESCRIPTION
Changes init.sh to overwrite mycron file everytime instead of adding entries to it. This fixes accumulating duplicates in the crontab file and spamming of the dns updates to the server. Fixes #15